### PR TITLE
bd/replacing `implementation` with `compile` in `build.gradle`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
* replacing `implementation` with `compile` in `build.gradle` to make it work with the older version of gradle we currently have